### PR TITLE
Zabbix Connection Fix & Corresponding Readme Update

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -231,6 +231,6 @@
   <properties>
     <jersey.version>2.31</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <buildDirectory>${project.basedir}/../target/autodeploy</buildDirectory>
+    <buildDirectory>${project.basedir}/../target</buildDirectory>
   </properties>
 </project>

--- a/backend/src/main/java/de/jsmenues/backend/zabbixapi/ZabbixUser.java
+++ b/backend/src/main/java/de/jsmenues/backend/zabbixapi/ZabbixUser.java
@@ -30,7 +30,7 @@ public class ZabbixUser {
         String zabbixUrl = configurationRepository.getVal(KEY_URL);
 
         // use standard values if none exist in redis
-        if (username == "" && password == "" && zabbixUrl == ""){
+        if (username.isEmpty() && password.isEmpty() && zabbixUrl.isEmpty()){
             username = "Admin";
             password = "zabbix";
             zabbixUrl = "http://zabbix-frontend:80/api_jsonrpc.php";

--- a/backend/src/main/java/de/jsmenues/backend/zabbixapi/ZabbixUser.java
+++ b/backend/src/main/java/de/jsmenues/backend/zabbixapi/ZabbixUser.java
@@ -29,6 +29,13 @@ public class ZabbixUser {
         String password = configurationRepository.getVal(KEY_PASSWORD);
         String zabbixUrl = configurationRepository.getVal(KEY_URL);
 
+        // use standard values if none exist in redis
+        if (username == "" && password == "" && zabbixUrl == ""){
+            username = "Admin";
+            password = "zabbix";
+            zabbixUrl = "http://zabbix-frontend:80/api_jsonrpc.php";
+        }
+
         return new ZabbixUser(username, password, zabbixUrl);
     }
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,7 +19,6 @@
   2. Backend:
     - In das Verzeichnis /backend mit der git bash wechseln
     - Mit `mvn clean install` das Backend bauen
-  3. Dateien backend.war und frontend.war von dem Verzeichnis js_menus\target\autodeploy in das Verzeichnis js_menus\target verschieben. Der Ordner autodeploy sollte nun leer sein.
 
 3. Starten von Payara und Redis als Container
   - Mit der Powershell in das Verzeichnis /docker wechseln

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -14,16 +14,23 @@
 
 2. Bauen der *.war Files: (mvn sollte im Path liegen)
   1. Frontend:
-    - In das Verzeichnis /fronend mit der git bash wechseln
+    - In das Verzeichnis /frontend mit der git bash wechseln
     - Mit `mvn clean install` das Frontend bauen
   2. Backend:
     - In das Verzeichnis /backend mit der git bash wechseln
     - Mit `mvn clean install` das Backend bauen
+  3. Dateien backend.war und frontend.war von dem Verzeichnis js_menus\target\autodeploy in das Verzeichnis js_menus\target verschieben. Der Ordner autodeploy sollte nun leer sein.
 
 3. Starten von Payara und Redis als Container
   - Mit der Powershell in das Verzeichnis /docker wechseln
   - Mit `docker-compose up -d` den Payara und Redis Service starten
+  - Auf der Payara Konsole unter https://localhost:4848/ mit Benutzername "admin" und Password "admin" einloggen
+  - Auf "List Deployed Applications" klicken
+  - Die Liste sollte leer sein, ansonsten alle Einträge auswählen und auf "Undeploy" klicken
+  - Auf "Deploy..." klicken und darauhin die backend.war Datei auswählen die im Verzeichnis js_menus\target liegt
+  - Auf "OK" klicken und analog für frontend.war ausführen
 
+Der Folgende Schritt ist derzeit nicht möglich:
 4. Setzen der Einstellungen für Zabbix in der Weboberfläche
   - Öffnen des Dashboards im Browser mit http://localhost:8080
   - Klick auf das Zahnrad oben rechts
@@ -76,3 +83,12 @@ Hinweis:
     - GET host_information/_search
     - GET history-dev1-*/_search
     - GET history-dev1-config.silbentrennung/_search
+
+
+# Fehlerbehebungen
+
+Falls beim Starten des Zabbix Containers folgende Meldung wiederholt erscheint:
+
+**** MySQL server is not available. Waiting 5 seconds...
+
+Dann die Container herunterfahren, den Inhalt dieses Ordners löschen: "js_menus\docker\zabbix\zbx_env\var\lib\mysql" und die Container wieder hochfahren.

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -74,7 +74,7 @@
               <directory>../target/angular/angular-radial-menu</directory>
             </resource>
           </webResources>
-          <outputDirectory>../target/autodeploy</outputDirectory>
+          <outputDirectory>../target</outputDirectory>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
adjusted readme to reflect the correct setup process

zabbixapi now uses standard values to connect to zabbix, if there are none saved in redis. The connection parameters should be changable through the frontend in the future.

explanation on how to resolve a common error with the connection of zabbix and the mysql container was added