### PR TITLE
Fixed Tests and Dependencies of the Backend to Compile with Java Versions greater than 15

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -181,12 +181,6 @@
     </dependency>
     <!-- testing -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
       <artifactId>jersey-test-framework-provider-jetty</artifactId>
       <scope>test</scope>

--- a/backend/src/test/java/de/jsmenues/backend/statistic/StatisticControllerTest.java
+++ b/backend/src/test/java/de/jsmenues/backend/statistic/StatisticControllerTest.java
@@ -155,12 +155,18 @@ public class StatisticControllerTest extends JerseyTest {
     public void uploadNewDataWithResultTrue() {
         //given
         FormDataMultiPart multiPart = new FormDataMultiPart();
+        /*
+         * TODO either this parameter has to be called "chart" or its name has to be changed in 
+         * in the StatisticController.uploadNewData implementation (this might break other calls though)
+         * The test works either way, because the checking method (statisticService.updateData)
+         * is mocked to return true
+         */
         multiPart.bodyPart(new FormDataBodyPart("chartName", ""));
         multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
-        when(service.updateData(anyString(), any(InputStream.class), any(FormDataContentDisposition.class))).thenReturn(true);
+        when(service.updateData(nullable(String.class), nullable(InputStream.class), nullable(FormDataContentDisposition.class))).thenReturn(true);
         //when
         Response response = target("/statistic/updateData").request().post(Entity.entity(multiPart, multiPart.getMediaType()), Response.class);
-        //then
+        //then 
         assertEquals(200, response.getStatus());
     }
 
@@ -209,10 +215,14 @@ public class StatisticControllerTest extends JerseyTest {
         multiPart.bodyPart(new FormDataBodyPart("file", String.valueOf(new ByteArrayInputStream(new byte[0]))));
         multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
         Response mockResonse = Response.ok().build();
-        when(service.createChart(anyString(), anyString(), anyString(), any(InputStream.class), any(FormDataContentDisposition.class))).thenReturn(mockResonse);
+        /*
+         * the expected "groupName" and "description" parameters in the API call "/createChart" are not defined in the FormData of this test,
+         * thus they will be received as null values. Since Mockito 2.1.0 anyString() can no longer be a null value. Thus nullable(String.class) has to be used.
+         */
+        when(service.createChart(anyString(), nullable(String.class), nullable(String.class), any(InputStream.class), any(FormDataContentDisposition.class))).thenReturn(mockResonse);
         Response response = target("/statistic/createChart").request().post(Entity.entity(multiPart, multiPart.getMediaType()), Response.class);
         //when
-        verify(service, times(1)).createChart(anyString(), anyString(), anyString(), any(InputStream.class), any(FormDataContentDisposition.class));
+        verify(service, times(1)).createChart(anyString(), nullable(String.class), nullable(String.class), any(InputStream.class), any(FormDataContentDisposition.class));
         //then
         assertEquals(200, response.getStatus());
     }


### PR DESCRIPTION
Removed "mockito-all" from the backends pom.xml dependencies list, as it is outdated and the updated "mockito-core" package is already a dependency.
The "mockito-core" package seemed to be previously overriten by the outdated "mockito-all" package, but through the removal is now active.
Because of updates in the Mockito Library the static method anyString() no longer accepts null values (since Mockito 2.1.0).
This resulted in two tests failing, as they called mocked methods that expected anyString() providing null values, which was previously accepted.
Thus these two tests were changed to use nullable(String.class) to implement the same functionality that was used before through the old implementation of anyString() (expects either null or given type, see https://javadoc.io/static/org.mockito/mockito-core/3.3.3/org/mockito/ArgumentMatchers.html#nullable-java.lang.Class-)
Because of the removal of the old "mockito-all" dependency, maven can now build the backend with Java versions greater than 15 with all tests running successfully. (Tested running Java 16)
